### PR TITLE
Fixed plugin not working in newer flow launcher versions (#1)

### DIFF
--- a/Flow.Launcher.Plugin.CPPreference/Flow - Backup.Launcher.Plugin.CPPreference.csproj
+++ b/Flow.Launcher.Plugin.CPPreference/Flow - Backup.Launcher.Plugin.CPPreference.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Flow.Launcher.Plugin.CPPreference</AssemblyName>
     <PackageId>Flow.Launcher.Plugin.CPPreference</PackageId>
     <Authors>Peter Schussheim</Authors>
@@ -13,7 +13,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Company>Peter Schussheim</Company>
-    <BaseOutputPath>bin\</BaseOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -37,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Flow.Launcher.Plugin" Version="4.1.1" />
+    <PackageReference Include="Flow.Launcher.Plugin" Version="1.4.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.33" />
   </ItemGroup>
 

--- a/Flow.Launcher.Plugin.CPPreference/Main.cs
+++ b/Flow.Launcher.Plugin.CPPreference/Main.cs
@@ -70,7 +70,7 @@ namespace Flow.Launcher.Plugin.CPPreference
                     IcoPath = icon_path,
                     Action = e =>
                     {
-                        url.NewTabInBrowser();
+                        url.OpenInBrowserTab();
                         return true;
                     }
                 };
@@ -92,7 +92,7 @@ namespace Flow.Launcher.Plugin.CPPreference
                         IcoPath = icon_path,
                         Action = e =>
                         {
-                            url.NewTabInBrowser();
+                            url.OpenInBrowserTab();
                             return true;
                         }
                     };
@@ -134,7 +134,7 @@ namespace Flow.Launcher.Plugin.CPPreference
                             {
                                 try
                                 {
-                                    query_url.NewTabInBrowser();
+                                    query_url.OpenInBrowserTab();
                                     return true;
                                 }
                                 catch (Exception)

--- a/Flow.Launcher.Plugin.CPPreference/plugin.json
+++ b/Flow.Launcher.Plugin.CPPreference/plugin.json
@@ -3,7 +3,7 @@
   "ActionKeyword": "cpp",
   "Name": "CPPreference",
   "Description": "Search cppreference.com efficiently",
-  "Author": "Peter Schussheim",
+  "Author": "Peter Schussheim, Jonas de Bruin",
   "Version": "1.0.1",
   "Language": "csharp",
   "Website": "https://github.com/peterschussheim/CPPreference-flow-plugin",


### PR DESCRIPTION
Fixes #1 
* Updated `Flow.Launcher.Plugin` from `1.4.0` to `4.1.1`
* Updated .NET version from `coreapp3.1` to `net7.0-windows`

* Changed all `NewTabInBrowser()` functions to `OpenInBrowserTab()` to fix the issue